### PR TITLE
feat(check-translations): implement search of unused translations script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # check-translations
+
+This package provides you with two scripts:
+
+* check-translations: compares all keys between different languages and finds which of them are not translated.
+* search-translations: finds all unused keys in your project. Keep in mind that it doesn't look for dynamically constructed keys, so be careful.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "./index.js",
   "bin": {
-    "check-translations": "./index-cli.js"
+    "check-translations": "./index-cli.js",
+    "search-translations": "./search-translations.js"
   },
   "files": [
     "index.js",

--- a/search-translations.js
+++ b/search-translations.js
@@ -1,4 +1,3 @@
-//requiring path and fs modules
 const path = require('path');
 const fs = require('fs');
 

--- a/search-translations.js
+++ b/search-translations.js
@@ -1,0 +1,38 @@
+//requiring path and fs modules
+const path = require('path');
+const fs = require('fs');
+
+console.log('Running search-translations...');
+
+const directoryPath = path.join(__dirname, process.argv[2]);
+const allFiles = walk(directoryPath);
+const files = allFiles.filter((f) => !f.includes('messages_'));
+const translationFile = allFiles.filter((f) => f.includes('messages_en'))[0];
+const allKeys = getAllKeys(translationFile);
+
+const usedKeys = new Set(files.flatMap(getKeysInFile));
+const unusedKeys = allKeys.filter((key) => !usedKeys.has(key));
+console.log('Unused keys:');
+console.log('----------------------------------------------------------------');
+console.log(unusedKeys.join('\n'));
+console.log('----------------------------------------------------------------');
+
+function getKeysInFile(file) {
+  const data = fs.readFileSync(file, 'utf8');
+  return allKeys.filter((key) => data.includes(key));
+}
+
+function walk(startPath) {
+  if (!fs.lstatSync(startPath).isDirectory()) {
+    return [startPath];
+  }
+  return fs
+    .readdirSync(startPath)
+    .map((p) => path.join(startPath, p))
+    .flatMap(walk);
+}
+
+function getAllKeys(translationFile) {
+  const data = fs.readFileSync(translationFile, 'utf8');
+  return Object.keys(JSON.parse(data));
+}


### PR DESCRIPTION
I didn't do search by splitting translations keys by dot because I got a lot of false positive cases. 